### PR TITLE
增加复制消息全部内容

### DIFF
--- a/src/renderer/components/chatroom-item.vue
+++ b/src/renderer/components/chatroom-item.vue
@@ -334,6 +334,14 @@
                     });
                 }
             }
+            else{
+                menu.push({
+                    label: '复制消息',
+                    click: () => {
+                        navigator.clipboard.writeText(this.item.md || this.$fishpi.chatroom.raw(this.item.oId))
+                    }
+                });
+            }
             if (this.item.userName == this.current.userName
             || ['纪律委员', 'OP', '管理员'].indexOf(this.current.userRole) >= 0) {
                 menu.push({


### PR DESCRIPTION
#51 
当要复制的内容是图片时，依然显示'复制图片'
![image](https://github.com/imlinhanchao/fishpi-desktop/assets/91249019/ca3629bb-71bd-48fa-bdb5-2c414e60191e)
